### PR TITLE
Avoid a warning about using EqPred uninitialized

### DIFF
--- a/SymbolicRangeAnalysis.cpp
+++ b/SymbolicRangeAnalysis.cpp
@@ -237,8 +237,10 @@ void SymbolicRangeAnalysis::handleBranch(BranchInst *BI, ICmpInst *ICI) {
     EqPred = Pred;
   else if (ICI->isTrueWhenEqual())
     EqPred = (ICmpInst::Predicate)(Pred - 1);
-  else if (ICI->isFalseWhenEqual())
+  else {
+    assert(ICI->isFalseWhenEqual());
     EqPred = (ICmpInst::Predicate)(Pred + 1);
+  }
   // 4) j <= i at cond.false;
   createNarrowingFn(RHS, LHS, EqPred, FB);
 }


### PR DESCRIPTION
With enough warning flags on, some compilers will warn that `EqPred` may be uninitialized in the call to `createNarrowingFn` at the very the end of `SymbolicRangeAnalysis::handleBranch`. However, this cannot actually happen:

In order for `EqPred` to be used uninitialized in the `createNarrowingFn` call, we would need to have an integer comparison instruction `ICI` for which `ICmpInst::isEquality`, `CmpInst::isTrueWhenEqual`, and `CmpInst::isFalseWhenEqual` all return false. Inspecting [`CmpInst::isTrueWhenEqual`](http://llvm.org/doxygen/Instructions_8cpp_source.html#l03235) and [`CmpInst::isFalseWhenEqual`](http://llvm.org/doxygen/Instructions_8cpp_source.html#l03243) closely, I find that for both of these to return false, the comparison predicate would need to be `FCMP_OEQ`, `FCMP_OGE`, `FCMP_OLE`, `FCMP_ORD`, `FCMP_UNO`, `FCMP_UGT`, `FCMP_ULT`, or `FCMP_UNE`. However, notice that these are all floating-point comparison predicates. Those should only appear as predicates for [`FCmpInst`](http://llvm.org/doxygen/classllvm_1_1FCmpInst.html) instructions, never for the [`ICmpInst`](http://llvm.org/doxygen/classllvm_1_1ICmpInst.html) instructions we'll have at this point in the code.

Thus, for integer comparison instructions, either `CmpInst::isTrueWhenEqual` or `CmpInst::isFalseWhenEqual` must be true, which means we must always initialize `EqPred`. The warning is spurious. This commit changes the last `if` into an `assert` to document what we know must be true.
