### PR TITLE
Fix various bad memory operations revealed by Valgrind

### DIFF
--- a/Redefinition.cpp
+++ b/Redefinition.cpp
@@ -39,7 +39,7 @@ static bool IsRedefinable(Value *V) {
 
 static PHINode *CreateNamedPhi(Value *V, Twine Prefix,
                                BasicBlock::iterator Position) {
-  Twine Name(V->hasName() ? Prefix + "." + V->getName() : Prefix);
+  const auto Name = (V->hasName() ? Prefix + "." + V->getName() : Prefix).str();
   return PHINode::Create(V->getType(), 1, Name, Position);
 }
 

--- a/SymbolicRangeAnalysis.cpp
+++ b/SymbolicRangeAnalysis.cpp
@@ -259,10 +259,8 @@ std::string SymbolicRangeAnalysis::makeName(Function *F, Value *V) {
     auto Name = (F->getName() + Twine("_") + V->getName()).str();
     std::replace(Name.begin(), Name.end(), '.', '_');
     return Name;
-  } else {
-    auto Name = F->getName() + Twine("_") + Twine(Temp++);
-    return Name.str();
-  }
+  } else
+    return (F->getName() + Twine("_") + Twine(Temp++)).str();
 }
 
 void SymbolicRangeAnalysis::setName(Value *V, std::string Name) {

--- a/SymbolicRangeAnalysis.cpp
+++ b/SymbolicRangeAnalysis.cpp
@@ -460,8 +460,9 @@ void SymbolicRangeAnalysis::reset(Function *F) {
 void SymbolicRangeAnalysis::iterate(Function *F) {
   DEBUG(dbgs() << "SRA: Iterate\n");
   while (!Worklist_.empty()) {
-    auto Next = Worklist_.begin(); Worklist_.erase(Next);
+    auto Next = Worklist_.begin();
     Instruction *I = Next->second;
+    Worklist_.erase(Next);
     if (Fn_.count(I) && !Evaled_.count(I)) {
       Evaled_.insert(I);
       setState(I, Fn_[I]());


### PR DESCRIPTION
These fixes address three bad memory operations. One involves use of an invalidated iterator. The other stems from unsafe use of `llvm::Twine` instances across statements. Regarding the latter, it's never safe to keep a `Twine` instance around longer than the end of the current statement. Per the LLVM documentation, “A `Twine` is not intended for use directly and should not be stored, its implementation relies on the ability to store pointers to temporary stack objects which may be deallocated at the end of a statement.”
